### PR TITLE
Sync from latest mature header on new wallet

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -42,6 +42,24 @@ namespace WalletWasabi.Backend.Controllers
 		public Global Global { get; }
 
 		/// <summary>
+		/// Get blockchain info
+		/// </summary>
+		/// <remarks>
+		/// Sample request:
+		///     GET /blockchainInfo
+		/// </remarks>
+		/// <returns></returns>
+		/// <response code="200">Returns array of fee estimations for the requested confirmation targets.</response>
+		[HttpGet("blockchainInfo")]
+		[ProducesResponseType(200)]
+		[ResponseCache(Duration = 300, Location = ResponseCacheLocation.Client)]
+		public async Task<IActionResult> GetBlockInfoAsync()
+		{
+			var blockInfo = await Global.RpcClient.GetBlockchainInfoAsync();
+			return Ok(blockInfo);
+		}
+
+		/// <summary>
 		/// Get fees for the requested confirmation targets based on Bitcoin Core's estimatesmartfee output.
 		/// </summary>
 		/// <remarks>

--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -57,7 +57,9 @@ namespace WalletWasabi.Backend.Controllers
 		public async Task<IActionResult> GetBlockInfoAsync()
 		{
 			var blockInfo = await RpcClient.GetBlockchainInfoAsync();
-			string output = JsonConvert.SerializeObject(blockInfo);
+			string output = JsonConvert.SerializeObject(blockInfo, new JsonSerializerSettings() {
+				ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+			});
 			return Ok(output);
 		}
 

--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
 using NBitcoin;
 using NBitcoin.RPC;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -55,8 +56,9 @@ namespace WalletWasabi.Backend.Controllers
 		[ResponseCache(Duration = 300, Location = ResponseCacheLocation.Client)]
 		public async Task<IActionResult> GetBlockInfoAsync()
 		{
-			var blockInfo = await Global.RpcClient.GetBlockchainInfoAsync();
-			return Ok(blockInfo);
+			var blockInfo = await RpcClient.GetBlockchainInfoAsync();
+			string output = JsonConvert.SerializeObject(blockInfo);
+			return Ok(output);
 		}
 
 		/// <summary>

--- a/WalletWasabi.Standard/Blockchain/BlockFilters/StartingFilters.cs
+++ b/WalletWasabi.Standard/Blockchain/BlockFilters/StartingFilters.cs
@@ -32,5 +32,11 @@ namespace WalletWasabi.Blockchain.BlockFilters
 				throw new NotSupportedNetworkException(network);
 			}
 		}
+
+		public static FilterModel GetStartingFilter(SmartHeader startingHeader)
+		{
+			GolombRiceFilter filter = IndexBuilderService.CreateDummyEmptyFilter(startingHeader.BlockHash);
+			return FilterModel.FromLine($"{startingHeader.Height}:{startingHeader.BlockHash}:{filter}:{startingHeader.PrevHash}:{startingHeader.BlockTime.ToUnixTimeSeconds()}");
+		}
 	}
 }

--- a/WalletWasabi.Standard/Stores/BitcoinStore.cs
+++ b/WalletWasabi.Standard/Stores/BitcoinStore.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using WalletWasabi.Backend.Models;
 using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Blockchain.Mempool;
 using WalletWasabi.Blockchain.P2p;
@@ -58,7 +59,7 @@ namespace WalletWasabi.Stores
 		/// </summary>
 		public UntrustedP2pBehavior CreateUntrustedP2pBehavior() => new UntrustedP2pBehavior(MempoolService);
 
-		public async Task InitializeAsync()
+		public async Task InitializeAsync(SmartHeader startingHeader = null)
 		{
 			using (BenchmarkLogger.Measure())
 			{
@@ -67,7 +68,7 @@ namespace WalletWasabi.Stores
 
 				var initTasks = new[]
 				{
-					IndexStore.InitializeAsync(indexStoreFolderPath),
+					IndexStore.InitializeAsync(indexStoreFolderPath, startingHeader),
 					TransactionStore.InitializeAsync(networkWorkFolderPath, Network)
 				};
 

--- a/WalletWasabi.Standard/Stores/BitcoinStore.cs
+++ b/WalletWasabi.Standard/Stores/BitcoinStore.cs
@@ -59,7 +59,7 @@ namespace WalletWasabi.Stores
 		/// </summary>
 		public UntrustedP2pBehavior CreateUntrustedP2pBehavior() => new UntrustedP2pBehavior(MempoolService);
 
-		public async Task InitializeAsync(SmartHeader startingHeader = null)
+		public async Task InitializeAsync()
 		{
 			using (BenchmarkLogger.Measure())
 			{
@@ -68,7 +68,7 @@ namespace WalletWasabi.Stores
 
 				var initTasks = new[]
 				{
-					IndexStore.InitializeAsync(indexStoreFolderPath, startingHeader),
+					IndexStore.InitializeAsync(indexStoreFolderPath),
 					TransactionStore.InitializeAsync(networkWorkFolderPath, Network)
 				};
 

--- a/WalletWasabi.Standard/Stores/IndexStore.cs
+++ b/WalletWasabi.Standard/Stores/IndexStore.cs
@@ -39,7 +39,7 @@ namespace WalletWasabi.Stores
 		private Network Network { get; }
 		private DigestableSafeMutexIoManager MatureIndexFileManager { get; set; }
 		private DigestableSafeMutexIoManager ImmatureIndexFileManager { get; set; }
-		public SmartHeaderChain SmartHeaderChain { get; }
+		public SmartHeaderChain SmartHeaderChain { get; private set; }
 
 		private FilterModel StartingFilter { get; set; }
 		private uint StartingHeight { get; set; }
@@ -86,6 +86,24 @@ namespace WalletWasabi.Stores
 
 					await InitializeFiltersAsync().ConfigureAwait(false);
 				}
+			}
+		}
+
+		public async Task ResetFromHeaderAsync(SmartHeader startingHeader)
+		{
+			using (await IndexLock.LockAsync().ConfigureAwait(false))
+			using (await MatureIndexFileManager.Mutex.LockAsync().ConfigureAwait(false))
+			using (await ImmatureIndexFileManager.Mutex.LockAsync().ConfigureAwait(false))
+			{
+				StartingFilter = StartingFilters.GetStartingFilter(startingHeader);
+				StartingHeight = StartingFilter.Header.Height;
+				ImmatureFilters = new List<FilterModel>(150);
+
+				SmartHeaderChain = new SmartHeaderChain(); // must be reset
+				MatureIndexFileManager.DeleteMe();
+				ImmatureIndexFileManager.DeleteMe();
+				await MatureIndexFileManager.WriteAllLinesAsync(new[] { StartingFilter.ToLine() }).ConfigureAwait(false);
+				await InitializeFiltersAsync().ConfigureAwait(false);
 			}
 		}
 


### PR DESCRIPTION
- backend serves latest "mature" header. Mature means 100 blocks back, too far back to be re-orged. Maybe not on testnet?
- client BitcoinStore / IndexStore modified to accept a startingHeader from which to sync filters
- UI re-initializes BitcoinStore when a new wallet is created at the latest mature header

Status: Wallet crashes on new wallet: `Index file consistency detected`

```
at WalletWasabi.Stores.IndexStore.ProcessLine IndexStore.cs:190
at IndexStore.InitializeFiltersAsync IndexStore.cs:161
at IndexStore.InitializeAsync IndexStore.cs:87
```
![Simulator Screen Shot - iPhone 11 - 2021-08-04 at 11 21 29](https://user-images.githubusercontent.com/8525467/128207913-5172ef1d-eb44-4877-93de-ae4f53064322.png)

