### PR TITLE
Anti-spam protection

### DIFF
--- a/WalletWasabi.Backend/Config.cs
+++ b/WalletWasabi.Backend/Config.cs
@@ -87,6 +87,10 @@ namespace WalletWasabi.Backend
 		[JsonProperty(PropertyName = "DatabaseConnectionStringName", DefaultValueHandling = DefaultValueHandling.Populate)]
 		public string DatabaseConnectionStringName { get; internal set; }
 
+		[DefaultValue(0)]
+		[JsonProperty(PropertyName = "HashCashDifficulty", DefaultValueHandling = DefaultValueHandling.Populate)]
+		public int HashCashDifficulty { get; internal set; }
+
 		[DefaultValue("/home/Dan/Downloads/AuthKey_4L3728R8LJ.p8")]
 		[JsonProperty(PropertyName = "APNsAuthKeyFile", DefaultValueHandling = DefaultValueHandling.Populate)]
 		public string APNsAuthKeyFile { get; internal set; }

--- a/WalletWasabi.Backend/Controllers/NotificationTokensController.cs
+++ b/WalletWasabi.Backend/Controllers/NotificationTokensController.cs
@@ -20,7 +20,6 @@ namespace WalletWasabi.Backend.Controllers
 	{
 		private class DeviceTokenHashCashFilter : HashCashFilter
 		{
-			public override int MinPow => 20;
 			public override TimeSpan MaxDifference { get; } = TimeSpan.FromMinutes(5);
 			public override string GetResource(ActionExecutingContext context)
 			{

--- a/WalletWasabi.Backend/Controllers/NotificationTokensController.cs
+++ b/WalletWasabi.Backend/Controllers/NotificationTokensController.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Caching.Memory;
 using NicolasDorier.RateLimits;
 using WalletWasabi.Backend.Data;
 using WalletWasabi.Backend.Models;
+using WalletWasabi.Backend.Polyfills;
 using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Backend.Controllers
@@ -81,11 +82,13 @@ namespace WalletWasabi.Backend.Controllers
 		{
 			await using var context = ContextFactory.CreateDbContext();
 			var token = await context.Tokens.FindAsync(tokenString);
-			if (token != null)
+			if (token == null)
 			{
-				context.Tokens.Remove(token);
-				await context.SaveChangesAsync();
+				return Ok();
 			}
+
+			context.Tokens.Remove(token);
+			await context.SaveChangesAsync();
 			return Ok();
 		}
 	}

--- a/WalletWasabi.Backend/Controllers/NotificationTokensController.cs
+++ b/WalletWasabi.Backend/Controllers/NotificationTokensController.cs
@@ -20,7 +20,7 @@ namespace WalletWasabi.Backend.Controllers
 	{
 		private class DeviceTokenHashCashFilter : HashCashFilter
 		{
-			public override int MinPow => 10;
+			public override int MinPow => 20;
 			public override TimeSpan MaxDifference { get; } = TimeSpan.FromMinutes(5);
 			public override string GetResource(ActionExecutingContext context)
 			{

--- a/WalletWasabi.Backend/Controllers/NotificationTokensController.cs
+++ b/WalletWasabi.Backend/Controllers/NotificationTokensController.cs
@@ -1,6 +1,11 @@
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using NicolasDorier.RateLimits;
 using WalletWasabi.Backend.Data;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Helpers;
@@ -12,6 +17,24 @@ namespace WalletWasabi.Backend.Controllers
 	[Produces("application/json")]
 	public class NotificationTokensController : ControllerBase
 	{
+		private class DeviceTokenHashCashFilter : HashCashFilter
+		{
+			public override int MinPow => 10;
+			public override TimeSpan MaxDifference { get; } = TimeSpan.FromMinutes(5);
+			public override string GetResource(ActionExecutingContext context)
+			{
+				switch (context.HttpContext.Request.Method)
+				{
+					case "PUT":
+						var dt = context.ActionArguments.Values.SingleOrDefault(pair => pair is DeviceToken) as DeviceToken;
+						return dt?.Token;
+					case "DELETE":
+						return context.RouteData.Values.TryGetValue("tokenString", out var tokenString) ? $"{tokenString}_delete" : null;
+				}
+				return base.GetResource(context);
+			}
+		}
+
 		private readonly IDbContextFactory<WasabiBackendContext> ContextFactory;
 
 		public NotificationTokensController(IDbContextFactory<WasabiBackendContext> contextFactory)
@@ -22,13 +45,14 @@ namespace WalletWasabi.Backend.Controllers
 		[HttpPut]
 		[ProducesResponseType(200)]
 		[ProducesResponseType(400)]
+		[RateLimitsFilter(ZoneLimits.NotificationTokens, Scope = RateLimitsScope.RemoteAddress)]
+		[DeviceTokenHashCashFilter]
 		public async Task<IActionResult> StoreTokenAsync([FromBody] DeviceToken token)
 		{
 			if (!ModelState.IsValid)
 			{
 				return BadRequest("Invalid device token.");
 			}
-
 			await using var context = ContextFactory.CreateDbContext();
 			var existingToken = await context.Tokens.FindAsync(token.Token);
 			if (existingToken != null)
@@ -51,6 +75,8 @@ namespace WalletWasabi.Backend.Controllers
 		/// <response code="200">Always return Ok, we should not confirm whether a token is in the db or not here</response>
 		[HttpDelete("{tokenString}")]
 		[ProducesResponseType(200)]
+		[DeviceTokenHashCashFilter]
+		[RateLimitsFilter(ZoneLimits.NotificationTokens, Scope = RateLimitsScope.RouteData, DataKey = "tokenString")]
 		public async Task<IActionResult> DeleteTokenAsync([FromRoute] string tokenString)
 		{
 			await using var context = ContextFactory.CreateDbContext();

--- a/WalletWasabi.Backend/Controllers/NotificationTokensController.cs
+++ b/WalletWasabi.Backend/Controllers/NotificationTokensController.cs
@@ -20,7 +20,7 @@ namespace WalletWasabi.Backend.Controllers
 	{
 		private class DeviceTokenHashCashFilter : HashCashFilter
 		{
-			public override TimeSpan MaxDifference { get; } = TimeSpan.FromMinutes(5);
+			public override TimeSpan ChallengeValidFor { get; } = TimeSpan.FromMinutes(5);
 			public override string GetResource(ActionExecutingContext context)
 			{
 				switch (context.HttpContext.Request.Method)

--- a/WalletWasabi.Backend/Data/MigrationStartupTask.cs
+++ b/WalletWasabi.Backend/Data/MigrationStartupTask.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using WalletWasabi.Backend.Polyfills;
 
 namespace WalletWasabi.Backend.Data
 {

--- a/WalletWasabi.Backend/HashCashFilter.cs
+++ b/WalletWasabi.Backend/HashCashFilter.cs
@@ -21,7 +21,7 @@ namespace WalletWasabi.Backend
 			return _resource;
 		}
 
-		public virtual TimeSpan MaxDifference { get; }
+		public virtual TimeSpan ChallengeValidFor { get; }
 		public virtual int? MinPow { get; }
 
 		protected HashCashFilter()
@@ -31,7 +31,7 @@ namespace WalletWasabi.Backend
 		public HashCashFilter(string resource, TimeSpan maxDifference, int? minPow)
 		{
 			_resource = resource;
-			MaxDifference = maxDifference;
+			ChallengeValidFor = maxDifference;
 			MinPow = minPow;
 		}
 
@@ -87,7 +87,7 @@ namespace WalletWasabi.Backend
 
 		private void CreateChallenge(string resource, int pow, IMemoryCache memoryCache, ActionExecutingContext context)
 		{
-			var expiry = DateTimeOffset.UtcNow.Add(MaxDifference);
+			var expiry = DateTimeOffset.UtcNow.Add(ChallengeValidFor);
 			var challenge = HashCashUtils.GenerateChallenge(resource, expiry, pow);
 
 			var cacheKey = $"{nameof(HashCashFilter)}_challenge_{challenge}";

--- a/WalletWasabi.Backend/HashCashFilter.cs
+++ b/WalletWasabi.Backend/HashCashFilter.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using WalletWasabi.Helpers;
+
+namespace WalletWasabi.Backend
+{
+	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+	public class HashCashFilter : Attribute, IActionFilter
+	{
+		private readonly string _resource;
+
+		public virtual string GetResource(ActionExecutingContext context)
+		{
+			return _resource;
+		}
+
+		public virtual TimeSpan MaxDifference { get; }
+		public virtual int MinPow { get; }
+
+		protected HashCashFilter()
+		{
+		}
+
+		public HashCashFilter(string resource, TimeSpan maxDifference, int minPow)
+		{
+			_resource = resource;
+			MaxDifference = maxDifference;
+			MinPow = minPow;
+		}
+
+		public void OnActionExecuted(ActionExecutedContext context)
+		{
+		}
+
+		public void OnActionExecuting(ActionExecutingContext context)
+		{
+			if (!context.HttpContext.Request.Headers.TryGetValue("X-Hashcash", out var xhashcash))
+			{
+				context.Result = new BadRequestObjectResult("Missing X-Hashcash header");
+			}
+
+			var resource = GetResource(context);
+			if (resource is null)
+			{
+				return;
+			}
+
+			var memoryCache = context.HttpContext.RequestServices.GetRequiredService<IMemoryCache>();
+
+			if (!HashCashUtils.Verify(xhashcash, MinPow, MaxDifference, resource, s =>
+			{
+				var cacheKey = $"{nameof(HashCashFilter)}_seed_{s}";
+				if(memoryCache.TryGetValue(cacheKey, out _))
+				{
+					return false;
+				}
+
+				memoryCache.CreateEntry(cacheKey).SlidingExpiration = TimeSpan.FromHours(1);
+				return true;
+			}))
+			{
+				context.Result = new BadRequestObjectResult(
+					$"Invalid hashcash computation ({MinPow} pow min with utc datetime less than {MaxDifference.ToString()} ago)");
+			}
+		}
+	}
+}

--- a/WalletWasabi.Backend/HashCashFilter.cs
+++ b/WalletWasabi.Backend/HashCashFilter.cs
@@ -22,13 +22,13 @@ namespace WalletWasabi.Backend
 		}
 
 		public virtual TimeSpan MaxDifference { get; }
-		public virtual int MinPow { get; }
+		public virtual int? MinPow { get; }
 
 		protected HashCashFilter()
 		{
 		}
 
-		public HashCashFilter(string resource, TimeSpan maxDifference, int minPow)
+		public HashCashFilter(string resource, TimeSpan maxDifference, int? minPow)
 		{
 			_resource = resource;
 			MaxDifference = maxDifference;
@@ -41,7 +41,9 @@ namespace WalletWasabi.Backend
 
 		public void OnActionExecuting(ActionExecutingContext context)
 		{
-			var pow = MinPow;
+
+			var config = context.HttpContext.RequestServices.GetRequiredService<Config>();
+			var pow = MinPow?? config.HashCashDifficulty;
 			var resource = GetResource(context);
 			if (resource is null || pow <= 0)
 			{

--- a/WalletWasabi.Backend/InitConfigStartupTask.cs
+++ b/WalletWasabi.Backend/InitConfigStartupTask.cs
@@ -12,6 +12,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Data;
+using WalletWasabi.Backend.Polyfills;
 using WalletWasabi.BitcoinCore;
 using WalletWasabi.CoinJoin.Coordinator.Rounds;
 using WalletWasabi.Logging;

--- a/WalletWasabi.Backend/Polyfills/DbContextFactory.cs
+++ b/WalletWasabi.Backend/Polyfills/DbContextFactory.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace WalletWasabi.Backend.Polyfills
+{
+	public class DbContextFactory<TContext>
+		: IDbContextFactory<TContext> where TContext : DbContext
+	{
+		private readonly IServiceProvider _provider;
+
+		public DbContextFactory(IServiceProvider provider)
+		{
+			_provider = provider;
+		}
+
+		public TContext CreateDbContext()
+		{
+			if (_provider == null)
+			{
+				throw new InvalidOperationException(
+					$"You must configure an instance of IServiceProvider");
+			}
+
+			return ActivatorUtilities.CreateInstance<TContext>(_provider);
+		}
+	}
+}

--- a/WalletWasabi.Backend/Polyfills/Extensions.cs
+++ b/WalletWasabi.Backend/Polyfills/Extensions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace WalletWasabi.Backend.Polyfills
+{
+	public static class Extensions
+	{
+		public static IServiceCollection AddDbContextFactory<TContext>(
+			this IServiceCollection collection,
+			Action<DbContextOptionsBuilder> optionsAction = null,
+			ServiceLifetime contextAndOptionsLifetime = ServiceLifetime.Singleton)
+			where TContext : DbContext
+		{
+			// instantiate with the correctly scoped provider
+			collection.Add(new ServiceDescriptor(
+				typeof(IDbContextFactory<TContext>),
+				sp => new DbContextFactory<TContext>(sp),
+				contextAndOptionsLifetime));
+
+			// dynamically run the builder on each request
+			collection.Add(new ServiceDescriptor(
+				typeof(DbContextOptions<TContext>),
+				sp => GetOptions<TContext>(optionsAction, sp),
+				contextAndOptionsLifetime));
+
+			return collection;
+		}
+		/// <summary>
+		/// Gets the options for a specific <seealso cref="TContext"/>.
+		/// </summary>
+		/// <param name="action">Option configuration action.</param>
+		/// <param name="sp">The scoped <see cref="IServiceProvider"/>.</param>
+		/// <returns>The newly configured <see cref="DbContextOptions{TContext}"/>.</returns>
+		private static DbContextOptions<TContext> GetOptions<TContext>(
+			Action<DbContextOptionsBuilder> action,
+			IServiceProvider sp = null) where TContext : DbContext
+		{
+			var optionsBuilder = new DbContextOptionsBuilder<TContext>();
+			if (sp != null)
+			{
+				optionsBuilder.UseApplicationServiceProvider(sp);
+			}
+			action?.Invoke(optionsBuilder);
+			return optionsBuilder.Options;
+		}
+
+	}
+}

--- a/WalletWasabi.Backend/Polyfills/Extensions.cs
+++ b/WalletWasabi.Backend/Polyfills/Extensions.cs
@@ -8,7 +8,7 @@ namespace WalletWasabi.Backend.Polyfills
 	{
 		public static IServiceCollection AddDbContextFactory<TContext>(
 			this IServiceCollection collection,
-			Action<DbContextOptionsBuilder> optionsAction = null,
+			Action<DbContextOptionsBuilder, IServiceProvider> optionsAction = null,
 			ServiceLifetime contextAndOptionsLifetime = ServiceLifetime.Singleton)
 			where TContext : DbContext
 		{
@@ -33,7 +33,7 @@ namespace WalletWasabi.Backend.Polyfills
 		/// <param name="sp">The scoped <see cref="IServiceProvider"/>.</param>
 		/// <returns>The newly configured <see cref="DbContextOptions{TContext}"/>.</returns>
 		private static DbContextOptions<TContext> GetOptions<TContext>(
-			Action<DbContextOptionsBuilder> action,
+			Action<DbContextOptionsBuilder, IServiceProvider> action,
 			IServiceProvider sp = null) where TContext : DbContext
 		{
 			var optionsBuilder = new DbContextOptionsBuilder<TContext>();
@@ -41,7 +41,8 @@ namespace WalletWasabi.Backend.Polyfills
 			{
 				optionsBuilder.UseApplicationServiceProvider(sp);
 			}
-			action?.Invoke(optionsBuilder);
+			action?.Invoke(optionsBuilder, sp);
+
 			return optionsBuilder.Options;
 		}
 

--- a/WalletWasabi.Backend/Polyfills/IDbContextFactory.cs
+++ b/WalletWasabi.Backend/Polyfills/IDbContextFactory.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace WalletWasabi.Backend.Polyfills
+{
+	public interface IDbContextFactory<TContext>where TContext : DbContext
+	{
+		TContext CreateDbContext();
+	}
+}

--- a/WalletWasabi.Backend/SendPushService.cs
+++ b/WalletWasabi.Backend/SendPushService.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using WalletWasabi.Backend.Data;
 using WalletWasabi.Backend.Models;
+using WalletWasabi.Backend.Polyfills;
 using WalletWasabi.Logging;
 
 namespace WalletWasabi.Backend

--- a/WalletWasabi.Backend/Startup.cs
+++ b/WalletWasabi.Backend/Startup.cs
@@ -69,9 +69,9 @@ namespace WalletWasabi.Backend
 			services.AddLogging(logging => logging.AddFilter((s, level) => level >= Microsoft.Extensions.Logging.LogLevel.Warning));
 
 
-			services.AddDbContextFactory<WasabiBackendContext>(builder =>
+			services.AddDbContextFactory<WasabiBackendContext>((builder, sp) =>
 			{
-				var connString = "User ID=postgres;Host=127.0.0.1;Port=65466;Database=wasabibackend;";
+				var connString = sp.GetService<Global>().Config.DatabaseConnectionStringName;
 				if (string.IsNullOrEmpty(connString))
 				{
 					throw new ArgumentNullException("Database", "Connection string not set");

--- a/WalletWasabi.Backend/Startup.cs
+++ b/WalletWasabi.Backend/Startup.cs
@@ -17,6 +17,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 using NicolasDorier.RateLimits;
 using WalletWasabi.Backend.Middlewares;
 using WalletWasabi.Backend.Data;
+using WalletWasabi.Backend.Polyfills;
 using WalletWasabi.Helpers;
 using WalletWasabi.Interfaces;
 using WalletWasabi.Logging;
@@ -68,7 +69,7 @@ namespace WalletWasabi.Backend
 			services.AddLogging(logging => logging.AddFilter((s, level) => level >= Microsoft.Extensions.Logging.LogLevel.Warning));
 
 
-			services.AddDbContextFactory<WasabiBackendContext>((provider, builder) =>
+			services.AddDbContextFactory<WasabiBackendContext>(builder =>
 			{
 				var connString = "User ID=postgres;Host=127.0.0.1;Port=65466;Database=wasabibackend;";
 				if (string.IsNullOrEmpty(connString))

--- a/WalletWasabi.Backend/WalletWasabi.Backend.csproj
+++ b/WalletWasabi.Backend/WalletWasabi.Backend.csproj
@@ -36,12 +36,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.20" />
     <PackageReference Include="NicolasDorier.RateLimits" Version="1.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.6" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.8">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.20" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.18" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.20" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.20">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/WalletWasabi.Backend/WalletWasabi.Backend.csproj
+++ b/WalletWasabi.Backend/WalletWasabi.Backend.csproj
@@ -36,6 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NicolasDorier.RateLimits" Version="1.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.6" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.7" />

--- a/WalletWasabi.Backend/ZoneLimits.cs
+++ b/WalletWasabi.Backend/ZoneLimits.cs
@@ -1,0 +1,9 @@
+﻿namespace WalletWasabi.Backend
+{
+	public class ZoneLimits
+	{
+		public const string NotificationTokens = nameof(NotificationTokens);
+	}
+
+
+}

--- a/WalletWasabi.Standard/Extensions/TorHttpClientExtensions.cs
+++ b/WalletWasabi.Standard/Extensions/TorHttpClientExtensions.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.Helpers;
 using WalletWasabi.TorSocks5;
 
 public static class TorHttpClientExtensions
@@ -12,26 +14,11 @@ public static class TorHttpClientExtensions
 	/// </remarks>
 	public static async Task<HttpResponseMessage> SendAndRetryAsync(this ITorHttpClient client, HttpMethod method, HttpStatusCode expectedCode, string relativeUri, int retry = 2, HttpContent content = null, CancellationToken cancel = default)
 	{
-		HttpResponseMessage response = null;
-		while (retry-- > 0)
+		var requestMessage = new HttpRequestMessage(method, new Uri(client.DestinationUri, relativeUri))
 		{
-			response?.Dispose();
-			cancel.ThrowIfCancellationRequested();
-			response = await client.SendAsync(method, relativeUri, content, cancel: cancel);
-			if (response.StatusCode == expectedCode)
-			{
-				break;
-			}
-			try
-			{
-				await Task.Delay(1000, cancel);
-			}
-			catch (TaskCanceledException ex)
-			{
-				throw new OperationCanceledException(ex.Message, ex, cancel);
-			}
-		}
-		return response;
+			Content = content
+		};
+		return await client.SendAndRetryAsync(requestMessage, expectedCode, retry, cancel);
 	}
 
 	public static async Task<HttpResponseMessage> SendAndRetryAsync(this ITorHttpClient client, HttpRequestMessage requestMessage, HttpStatusCode expectedCode, int retry = 2, CancellationToken cancel = default)
@@ -48,7 +35,16 @@ public static class TorHttpClientExtensions
 			}
 			try
 			{
-				await Task.Delay(1000, cancel);
+				if (response.Headers.TryGetValues("X-Hashcash-Challenge", out var challenge))
+				{
+					requestMessage.Headers.Remove("X-Hashcash");
+					requestMessage.Headers.Add("X-Hashcash", HashCashUtils.ComputeFromChallenge(challenge.First()));
+				}
+
+				if (!response.Headers.TryGetValues("X-Hashcash-Error", out _))
+				{
+					await Task.Delay(1000, cancel);
+				}
 			}
 			catch (TaskCanceledException ex)
 			{

--- a/WalletWasabi.Standard/Helpers/HashCashUtils.cs
+++ b/WalletWasabi.Standard/Helpers/HashCashUtils.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections;
+using System.Security.Cryptography;
+using System.Text;
+using NBitcoin;
+
+namespace WalletWasabi.Helpers
+{
+	public static class HashCashUtils
+	{
+		private static string GenerateString(int length)
+		{
+			var r = new Random(RandomUtils.GetInt32());
+
+			var letters = new char[length];
+
+			for (var i = 0; i < length; i++)
+			{
+				letters[i] = (char) (r.Next('A', 'Z' + 1));
+			}
+			return new string(letters);
+		}
+		public static string Compute(int bits, string resource)
+		{
+			var counter = int.MinValue;
+			var headerParts = new[]
+			{
+				"1",
+				bits.ToString(),
+				DateTime.UtcNow.ToString("yyMMddhhmmss"),
+				resource,
+				"",
+				Convert.ToBase64String(Encoding.UTF8.GetBytes(GenerateString(10))),
+				Convert.ToBase64String(BitConverter.GetBytes(counter))
+			};
+
+			var currentStamp = string.Join(":", headerParts);
+
+			while (!AcceptableHeader(currentStamp, bits))
+			{
+				counter++;
+
+				// Failed
+				if (counter == int.MaxValue)
+				{
+					headerParts[5] = Convert.ToBase64String(Encoding.UTF8.GetBytes(GenerateString(10)));
+					counter = int.MinValue;
+				}
+
+				headerParts[6] = Convert.ToBase64String(BitConverter.GetBytes(counter));
+				currentStamp = string.Join(":", headerParts);
+
+				++counter;
+			}
+
+			return currentStamp;
+		}
+
+		private  static bool AcceptableHeader(string header, int bits)
+		{
+			var sha = new SHA1CryptoServiceProvider();
+			var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(header));
+			return GetStampHashDenomination(hash) == bits;
+		}
+
+		public static bool Verify(string header, int bitsMin, TimeSpan allowedDiff, string resource, Func<string, bool> isSeedValid = null)
+		{
+			var parts = header.Split(':');
+			if (parts[0] != "1")
+			{
+				return false;
+			}
+			var zbits = int.Parse(parts[1]);
+			if (zbits < bitsMin)
+			{
+				return false;
+			}
+
+			if (DateTime.UtcNow - DateTime.ParseExact(parts[2], "yyMMddhhmmss", null ) < allowedDiff)
+			{
+				return false;
+			}
+
+			if (resource != parts[3])
+			{
+				return false;
+			}
+
+			if (!string.IsNullOrEmpty(parts[4]))
+			{
+				return false;
+			}
+			if (!string.IsNullOrEmpty(parts[5]) && (isSeedValid is null || isSeedValid(parts[5])))
+			{
+				return false;
+			}
+
+			var sha = new SHA1CryptoServiceProvider();
+			var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(header));
+			return GetStampHashDenomination(hash) == zbits;
+		}
+
+		private static int GetStampHashDenomination(byte[] stampHash)
+		{
+			var continuousBits = new BitArray(stampHash);
+			var denomination = 0;
+			for (var bitIndex = 0; bitIndex < continuousBits.Length; bitIndex++)
+			{
+				var bit = continuousBits[bitIndex];
+
+				if (bit)
+				{
+					break;
+				}
+
+				denomination++;
+			}
+
+			return denomination;
+		}
+	}
+}

--- a/WalletWasabi.Standard/Helpers/HashCashUtils.cs
+++ b/WalletWasabi.Standard/Helpers/HashCashUtils.cs
@@ -90,7 +90,7 @@ namespace WalletWasabi.Helpers
 			{
 				return false;
 			}
-			if (!string.IsNullOrEmpty(parts[5]) && (isSeedValid is null || isSeedValid(parts[5])))
+			if (string.IsNullOrEmpty(parts[5]) || !(isSeedValid is null || isSeedValid(parts[5])))
 			{
 				return false;
 			}

--- a/WalletWasabi.Standard/WebClients/Wasabi/WasabiClient.cs
+++ b/WalletWasabi.Standard/WebClients/Wasabi/WasabiClient.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Backend.Models.Responses;
 using WalletWasabi.Bases;
@@ -297,9 +298,9 @@ namespace WalletWasabi.WebClients.Wasabi
 
 		public async Task<string>  RegisterNotificationTokenAsync(DeviceToken deviceToken,CancellationToken cancel)
 		{
-			var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v{ApiVersion}/notificationTokens")
+			var request = new HttpRequestMessage(HttpMethod.Put, new Uri(TorClient.DestinationUri, $"/api/v{ApiVersion}/notificationTokens"))
 			{
-				Content = new StringContent(JsonConvert.ToString(deviceToken), Encoding.UTF8, "application/json"),
+				Content = new StringContent(JObject.FromObject(deviceToken).ToString(), Encoding.UTF8, "application/json"),
 				Headers = { { "X-Hashcash", new[] { HashCashUtils.Compute(10, deviceToken.Token) } } }
 			};
 
@@ -320,7 +321,7 @@ namespace WalletWasabi.WebClients.Wasabi
 
 		public async Task<string>  RemoveNotificationTokenAsync(string deviceToken,CancellationToken cancel)
 		{
-			var request = new HttpRequestMessage(HttpMethod.Delete, $"/api/v{ApiVersion}/notificationTokens/{deviceToken}")
+			var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(TorClient.DestinationUri,$"/api/v{ApiVersion}/notificationTokens/{deviceToken}"))
 			{
 				Headers = { { "X-Hashcash", new[] { HashCashUtils.Compute(10, $"{deviceToken}_delete") } } }
 			};

--- a/WalletWasabi.Standard/WebClients/Wasabi/WasabiClient.cs
+++ b/WalletWasabi.Standard/WebClients/Wasabi/WasabiClient.cs
@@ -296,18 +296,16 @@ namespace WalletWasabi.WebClients.Wasabi
 
 		#region Chaincase
 
-		public async Task<string>  RegisterNotificationTokenAsync(DeviceToken deviceToken,CancellationToken cancel)
+		public async Task<string> RegisterNotificationTokenAsync(DeviceToken deviceToken, CancellationToken cancel)
 		{
-			var request = new HttpRequestMessage(HttpMethod.Put, new Uri(TorClient.DestinationUri, $"/api/v{ApiVersion}/notificationTokens"))
-			{
-				Content = new StringContent(JObject.FromObject(deviceToken).ToString(), Encoding.UTF8, "application/json"),
-				Headers = { { "X-Hashcash", new[] { HashCashUtils.Compute(10, deviceToken.Token) } } }
-			};
-
 			using var response = await TorClient.SendAndRetryAsync(
-				request,
+				HttpMethod.Put,
 				HttpStatusCode.OK,
-				2, cancel).ConfigureAwait(false);
+				$"/api/v{ApiVersion}/notificationTokens",
+				2,
+				new StringContent(JObject.FromObject(deviceToken).ToString(), Encoding.UTF8,
+					"application/json")
+				, cancel).ConfigureAwait(false);
 
 			if (response.StatusCode != HttpStatusCode.OK)
 			{
@@ -319,23 +317,18 @@ namespace WalletWasabi.WebClients.Wasabi
 			return ret;
 		}
 
-		public async Task<string>  RemoveNotificationTokenAsync(string deviceToken,CancellationToken cancel)
+		public async Task<string> RemoveNotificationTokenAsync(string deviceToken, CancellationToken cancel)
 		{
-			var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(TorClient.DestinationUri,$"/api/v{ApiVersion}/notificationTokens/{deviceToken}"))
-			{
-				Headers = { { "X-Hashcash", new[] { HashCashUtils.Compute(10, $"{deviceToken}_delete") } } }
-			};
-
 			using var response = await TorClient.SendAndRetryAsync(
-				request,
+				HttpMethod.Delete,
 				HttpStatusCode.OK,
-				2, cancel).ConfigureAwait(false);
+				$"/api/v{ApiVersion}/notificationTokens/{deviceToken}",
+				2,null, cancel).ConfigureAwait(false);
 
 			if (response.StatusCode != HttpStatusCode.OK)
 			{
 				await response.ThrowRequestExceptionFromContentAsync();
 			}
-
 			using HttpContent content = response.Content;
 			var ret = await content.ReadAsStringAsync().ConfigureAwait(false);
 			return ret;

--- a/WalletWasabi.Tests/RegressionTests/BackendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BackendTests.cs
@@ -17,6 +17,8 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using WalletWasabi.Backend;
 using WalletWasabi.Backend.Controllers;
 using WalletWasabi.Backend.Data;
@@ -273,8 +275,21 @@ namespace WalletWasabi.Tests.RegressionTests
 		#region Chaincase Backend Tests
 
 		[Fact]
+		public async Task HashcashTests()
+		{
+			var challenge = HashCashUtils.GenerateChallenge("chocolate", DateTimeOffset.UtcNow.AddMinutes(5), 20);
+			var stamp = HashCashUtils.ComputeFromChallenge(challenge);
+			Assert.True(HashCashUtils.Verify(stamp));
+		}
+
+		[Fact]
 		public async Task NotificationsTests()
 		{
+			var jobj = JObject.FromObject(RegTestFixture.Global.Config);
+			Assert.Equal(0, jobj["HashCashDifficulty"].Value<int>());
+			jobj["HashCashDifficulty"] = 10;
+			JsonConvert.PopulateObject(jobj.ToString(), RegTestFixture.Global.Config);
+			Assert.Equal(10, RegTestFixture.Global.Config.HashCashDifficulty);
 			using var client = new WasabiClient(new Uri(RegTestFixture.BackendEndPoint), null);
 			_ = await client.RegisterNotificationTokenAsync(new DeviceToken()
 			{

--- a/WalletWasabi.Tests/RegressionTests/BackendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BackendTests.cs
@@ -266,5 +266,33 @@ namespace WalletWasabi.Tests.RegressionTests
 		#endregion BackendTests
 
 #pragma warning restore IDE0059 // Value assigned to symbol is never used
+
+		#region Chaincase Backend Tests
+
+		[Fact]
+		public async Task NotificationsTests()
+		{
+			using var client = new WasabiClient(new Uri(RegTestFixture.BackendEndPoint), null);
+			_ = await client.RegisterNotificationTokenAsync(new DeviceToken()
+			{
+				Status = TokenStatus.New,
+				Token = "123456",
+				Type = TokenType.AppleDebug
+			}, CancellationToken.None);
+			var x = await Assert.ThrowsAsync<HttpRequestException>(async () =>
+			{
+				_ = await client.RegisterNotificationTokenAsync(new DeviceToken()
+				{
+					Status = TokenStatus.New,
+					Token = "123456",
+					Type = TokenType.AppleDebug
+				}, CancellationToken.None);
+			});
+			Assert.Contains(HttpStatusCode.BadRequest.ToReasonString(), x.Message);
+
+		}
+
+		#endregion
+
 	}
 }

--- a/WalletWasabi.Tests/RegressionTests/BackendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BackendTests.cs
@@ -16,8 +16,10 @@ using System.Security;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using WalletWasabi.Backend;
 using WalletWasabi.Backend.Controllers;
+using WalletWasabi.Backend.Data;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Backend.Models.Responses;
 using WalletWasabi.BitcoinCore;
@@ -279,6 +281,13 @@ namespace WalletWasabi.Tests.RegressionTests
 				Token = "123456",
 				Type = TokenType.AppleDebug
 			}, CancellationToken.None);
+
+			var factory = RegTestFixture.BackendHost.Services.GetService<IDbContextFactory<WasabiBackendContext>>();
+			await using var context = factory.CreateDbContext();
+			Assert.NotNull(await context.FindAsync<DeviceToken>("123456"));
+			await using var context2 = factory.CreateDbContext();
+			_ = await client.RemoveNotificationTokenAsync("123456", CancellationToken.None);
+			Assert.Null(await context2.FindAsync<DeviceToken>("123456"));
 			_ = await client.RemoveNotificationTokenAsync("123456", CancellationToken.None);
 
 		}

--- a/WalletWasabi.Tests/RegressionTests/BackendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BackendTests.cs
@@ -279,16 +279,7 @@ namespace WalletWasabi.Tests.RegressionTests
 				Token = "123456",
 				Type = TokenType.AppleDebug
 			}, CancellationToken.None);
-			var x = await Assert.ThrowsAsync<HttpRequestException>(async () =>
-			{
-				_ = await client.RegisterNotificationTokenAsync(new DeviceToken()
-				{
-					Status = TokenStatus.New,
-					Token = "123456",
-					Type = TokenType.AppleDebug
-				}, CancellationToken.None);
-			});
-			Assert.Contains(HttpStatusCode.BadRequest.ToReasonString(), x.Message);
+			_ = await client.RemoveNotificationTokenAsync("123456", CancellationToken.None);
 
 		}
 

--- a/WalletWasabi.Tests/RegressionTests/BackendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BackendTests.cs
@@ -22,6 +22,7 @@ using WalletWasabi.Backend.Controllers;
 using WalletWasabi.Backend.Data;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Backend.Models.Responses;
+using WalletWasabi.Backend.Polyfills;
 using WalletWasabi.BitcoinCore;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.BlockFilters;


### PR DESCRIPTION
This PR adds anti spam protection for the new notifications endpoints.  There are actually 2 mechanisms introduced here:
* A hashcash implementation where the client must now provide a X-Hashcash header with a v1 hashcash stamp with sufficient pow -- UPDATE: I adapted to use the HTTP Hashcash deviation (https://therootcompany.com/blog/http-hashcash/)
* A rate limiter where: token submission is throttled based on user ip and token deletion is throttled by the token being deleted